### PR TITLE
Minor improvements as discussed

### DIFF
--- a/client/ontrackGraphQLClient.go
+++ b/client/ontrackGraphQLClient.go
@@ -38,6 +38,10 @@ func GraphQLCall(cfg *config.Config, query string, variables map[string]interfac
 		return err
 	}
 
+	if resp.IsError() {
+		return fmt.Errorf("%s:\n%s", resp.Status(), resp.Body())
+	}
+
 	// Error returned
 	var error struct {
 		Status  int

--- a/client/validations.go
+++ b/client/validations.go
@@ -15,6 +15,7 @@ func ValidateWithTests(
 	passed int,
 	skipped int,
 	failed int,
+	status *string,
 ) error {
 
 	// Mutation payload
@@ -37,7 +38,8 @@ func ValidateWithTests(
 				$runInfo: RunInfoInput,
 				$passed: Int!,
 				$skipped: Int!,
-				$failed: Int!
+				$failed: Int!,
+				$status: String
 			) {
 				validateBuildWithTests(input: {
 					project: $project,
@@ -48,7 +50,8 @@ func ValidateWithTests(
 					runInfo: $runInfo,
 					passed: $passed,
 					skipped: $skipped,
-					failed: $failed
+					failed: $failed,
+					status: $status
 				}) {
 					errors {
 						message
@@ -65,6 +68,7 @@ func ValidateWithTests(
 		"passed":          passed,
 		"skipped":         skipped,
 		"failed":          failed,
+		"status":          status,
 	}, &payload); err != nil {
 		return err
 	}

--- a/cmd/configCreate.go
+++ b/cmd/configCreate.go
@@ -31,6 +31,7 @@ import (
 var username string
 var password string
 var token string
+var connectionRetry config.ConnectionRetry
 
 // configCreateCmd represents the configCreate command
 var configCreateCmd = &cobra.Command{
@@ -64,11 +65,12 @@ func createConfig(cmd *cobra.Command, args []string) error {
 
 	// Creates the configuration
 	var cfg = config.Config{
-		Name:     name,
-		URL:      url,
-		Username: username,
-		Password: password,
-		Token:    token,
+		Name:            name,
+		URL:             url,
+		Username:        username,
+		Password:        password,
+		Token:           token,
+		ConnectionRetry: connectionRetry,
 	}
 
 	// Adds this configuration to the file
@@ -99,4 +101,6 @@ func init() {
 	configCreateCmd.Flags().StringVarP(&password, "password", "p", "", "Password for basic authentication")
 	configCreateCmd.Flags().StringVarP(&token, "token", "t", "", "Token based authentication (if defined, takes priority over username/password authentication)")
 	configCreateCmd.Flags().BoolP("override", "o", false, "Overrides the configuration if it already exists")
+	configCreateCmd.Flags().IntVarP(&connectionRetry.MaxWaitTimeSec, "conn-retry-wait", "", 2, "Max connection retry wait time between attempts in seconds")
+	configCreateCmd.Flags().IntVarP(&connectionRetry.MaxCount, "conn-retry-count", "", 5, "Max connection retry attempts")
 }

--- a/cmd/validateTests.go
+++ b/cmd/validateTests.go
@@ -103,6 +103,7 @@ For example:
 			passed,
 			skipped,
 			failed,
+			nil,
 		)
 	},
 }

--- a/config/configService.go
+++ b/config/configService.go
@@ -3,11 +3,10 @@ package config
 import (
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -36,6 +35,13 @@ type Config struct {
 	Token string
 	// Is this configuration disabled?
 	Disabled bool
+	// Connection retry configuration
+	ConnectionRetry `yaml:"connectionRetry"`
+}
+
+type ConnectionRetry struct {
+	MaxWaitTimeSec int `yaml:"maxWaitTimeSec"`
+	MaxCount       int `yaml:"maxcount"`
 }
 
 // Gets the current configuration


### PR DESCRIPTION
- option to fail junit validation when all counters are 0
- print original issue when http fails (instead of graphql parsing error for non-graphql responses, e.g. 503 from load balancer) 
- connection retries 