### PR TITLE
feat: use config global parameter for yontrack configuration file path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,18 +22,10 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"fmt"
-	"os"
+	"yontrack/config"
 
 	"github.com/spf13/cobra"
-
-	config "yontrack/config"
-
-	homedir "github.com/mitchellh/go-homedir"
-	"github.com/spf13/viper"
 )
-
-var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -87,36 +79,11 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
-
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.yontrack.yaml)")
+	rootCmd.PersistentFlags().StringVar(&config.ConfigFilePath, "config", "./.yontrack-config.yaml", "Configuration file path.")
 
 	rootCmd.PersistentFlags().BoolVar(&config.GraphQLLogging, "graphql-log", false, "Enable traces on the GraphQL calls.")
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".yontrack" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".yontrack")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
 }

--- a/config/configService.go
+++ b/config/configService.go
@@ -3,14 +3,11 @@ package config
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
+	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-)
 
-const (
-	configFileName = ".yontrack-config.yaml"
+	"gopkg.in/yaml.v2"
 )
 
 // Root configuration
@@ -78,9 +75,9 @@ func ReadRootConfiguration() (*RootConfig, error) {
 	}
 
 	reader, _ := os.Open(configFilePath)
-	buf, _ := ioutil.ReadAll(reader)
-	yaml.Unmarshal(buf, &root)
-	return &root, nil
+	buf, _ := io.ReadAll(reader)
+	err = yaml.Unmarshal(buf, &root)
+	return &root, err
 }
 
 // Adds a new configuration and set as default
@@ -165,7 +162,7 @@ func SetSelectedConfiguration(name string) error {
 	}
 	buf, _ := yaml.Marshal(newRoot)
 	_, _ = os.OpenFile(configFilePath, os.O_CREATE|os.O_WRONLY, 0600)
-	_ = ioutil.WriteFile(configFilePath, buf, 0600)
+	_ = os.WriteFile(configFilePath, buf, 0600)
 
 	// OK
 	return nil
@@ -191,7 +188,7 @@ func SetConfigurationState(name string, disabled bool) error {
 	}
 	buf, _ := yaml.Marshal(root)
 	_, _ = os.OpenFile(configFilePath, os.O_CREATE|os.O_WRONLY, 0600)
-	_ = ioutil.WriteFile(configFilePath, buf, 0600)
+	_ = os.WriteFile(configFilePath, buf, 0600)
 
 	// OK
 	return nil
@@ -199,10 +196,5 @@ func SetConfigurationState(name string, disabled bool) error {
 
 // Gets the path to the configuration file
 func getConfigFilePath() (string, error) {
-	path, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	configFilePath := filepath.Join(path, configFileName)
-	return configFilePath, nil
+	return ConfigFilePath, nil
 }

--- a/config/vars.go
+++ b/config/vars.go
@@ -5,3 +5,6 @@ var Version = "Snapshot"
 
 // GraphQL logging flag
 var GraphQLLogging bool = false
+
+// Configuration file path
+var ConfigFilePath string


### PR DESCRIPTION
viper wasn't used so I removed it and re-used the global `config` parameter for the yontrack configuration file